### PR TITLE
use allreduce operation to sync trainers

### DIFF
--- a/plsc/entry.py
+++ b/plsc/entry.py
@@ -550,8 +550,11 @@ class Entry(object):
 
             # sync all trainers to avoid loading checkpoints before 
             # parameters are downloaded
-            file_name = os.path.join(checkpoint_dir, '.lock')
+            file_name = os.path.join(checkpoint_dir, '.download_lock')
             if self.trainer_id == 0:
+                if os.path.exists(file_name):
+                    logger.error("Why the file {} exists?".format(file_name))
+                    exit()
                 self.get_files_from_hdfs()
                 with open(file_name, 'w') as f:
                     pass
@@ -565,7 +568,7 @@ class Entry(object):
                         break
         
         # Preporcess distributed parameters.
-        file_name = os.path.join(checkpoint_dir, '.lock')
+        file_name = os.path.join(checkpoint_dir, '.convertor_lock')
         meta_file = os.path.join(checkpoint_dir, 'meta.json')
         if not os.path.exists(meta_file):
             logger.error("Please make sure the checkpoint dir {} exists, and "
@@ -574,6 +577,9 @@ class Entry(object):
             exit()
         distributed = self.loss_type in ["dist_softmax", "dist_arcface"]
         if load_for_train and self.trainer_id == 0 and distributed:
+            if os.path.exists(file_name):
+                logger.error("Why the file {} exists?".format(file_name))
+                exit()
             self.process_distributed_params(checkpoint_dir)
             with open(file_name, 'w') as f:
                 pass

--- a/plsc/entry.py
+++ b/plsc/entry.py
@@ -585,9 +585,7 @@ class Entry(object):
             # parameters are downloaded
             if self.trainer_id == 0:
                 self.get_files_from_hdfs()
-                self._sync_program()
-            else:
-                self._sync_program()
+            self._sync_program()
         
         # Preporcess distributed parameters.
         meta_file = os.path.join(checkpoint_dir, 'meta.json')

--- a/plsc/entry.py
+++ b/plsc/entry.py
@@ -545,19 +545,6 @@ class Entry(object):
             out = fluid.layers.collective._c_allreduce(sync_data,
                                                        use_calc_stream=True)
 
-        worker_endpoints = os.getenv("PADDLE_TRAINER_ENDPOINTS")
-        current_endpoint = os.getenv("PADDLE_CURRENT_ENDPOINT")
-
-        config = dist_transpiler.DistributeTranspilerConfig()
-        config.mode = "collective"
-        config.collective_mode = "grad_allreduce"
-        t = dist_transpiler.DistributeTranspiler(config=config)
-        t.transpile(trainer_id=self.trainer_id,
-                    trainers=worker_endpoints,
-                    startup_program=startup_prog,
-                    program=main_prog,
-                    current_endpoint=current_endpoint)
-
         gpu_id = int(os.getenv("FLAGS_selected_gpus", 0))
         place = fluid.CUDAPlace(gpu_id)
         exe = fluid.Executor(place)

--- a/plsc/entry.py
+++ b/plsc/entry.py
@@ -539,9 +539,8 @@ class Entry(object):
         startup_prog = fluid.Program()
         main_prog = fluid.Program()
         with fluid.program_guard(main_prog, startup_prog):
-            sync_data = fluid.layers.fill_constant(shape=[1],
-                                                   value=0,
-                                                   dtype="float32")
+            sync_data = fluid.layers.create_parameter(shape=[1],
+                                                      dtype="float32")
             out = fluid.layers.collective._c_allreduce(sync_data,
                                                        use_calc_stream=True)
 
@@ -555,7 +554,7 @@ class Entry(object):
         t.transpile(trainer_id=self.trainer_id,
                     trainers=worker_endpoints,
                     startup_program=startup_prog,
-                    program=self.main_prog,
+                    program=main_prog,
                     current_endpoint=current_endpoint)
 
         gpu_id = int(os.getenv("FLAGS_selected_gpus", 0))


### PR DESCRIPTION
use allreduce operation to sync trainers for some tasks such as downloading.

Todo:
   maybe run a global startup once to avoid generating a new ring at each startup program running.