### PR TITLE
update api to paddle 2.1

### DIFF
--- a/plsc/models/resnet.py
+++ b/plsc/models/resnet.py
@@ -63,18 +63,14 @@ class ResNet(BaseModel):
             epsilon=2e-05,
             is_test=False if is_train else True)
         drop = paddle.nn.functional.dropout(
-            x=bn,
-            dropout_prob=0.4,
-            mode='upscale_in_train',
-            training=True if is_train else False)
+            x=bn, p=0.4, training=is_train, mode='upscale_in_train')
         fc = paddle.static.nn.fc(
-            input=drop,
+            x=drop,
             size=self.emb_dim,
-            param_attr=paddle.ParamAttr(
-                initializer=paddle.nn.initializer.Xavier(
-                    uniform=False, fan_in=0.0)),
+            weight_attr=paddle.ParamAttr(
+                initializer=paddle.nn.initializer.XavierNormal(fan_in=0.0)),
             bias_attr=paddle.ParamAttr(
-                initializer=paddle.nn.initializer.ConstantInitializer()))
+                initializer=paddle.nn.initializer.Constant()))
         emb = paddle.static.nn.batch_norm(
             input=fc,
             act=None,
@@ -99,8 +95,7 @@ class ResNet(BaseModel):
             padding=pad,
             groups=groups,
             param_attr=paddle.ParamAttr(
-                initializer=paddle.nn.initializer.Xavier(
-                    uniform=False, fan_in=0.0)),
+                initializer=paddle.nn.initializer.XavierNormal(fan_in=0.0)),
             bias_attr=False)
         if act == 'prelu':
             bn = paddle.static.nn.batch_norm(
@@ -179,7 +174,7 @@ class ResNet(BaseModel):
                 is_train=is_train)
 
         short = self.shortcut(input, num_filters, stride, is_train=is_train)
-        return paddle.elementwise_add(x=short, y=conv2, act=None)
+        return paddle.add(short, conv2)
 
 
 def ResNet50(emb_dim=512):

--- a/plsc/utils/fp16_utils.py
+++ b/plsc/utils/fp16_utils.py
@@ -14,8 +14,8 @@
 
 from __future__ import print_function
 
-from paddle import core
-from paddle.fluid import layers
+from paddle.fluid import core
+from paddle.fluid.layer_helper import LayerHelper
 
 
 def _rename_arg(op, old_name, new_name):
@@ -350,10 +350,10 @@ def check_finite_and_unscale(x, scale, name=None):
         x(list|tuple): The input tensors of check_finite_and_unscale operator.
         scale: The scale of check_finite_and_unscale operator.
     """
-    check_type(x, 'x', (tuple, list), 'check_finite_and_unscale')
-    for e in x:
-        check_variable_and_dtype(e, "x", ['float16', 'float32', 'float64'],
-                                 'check_finite_and_unscale')
+    #check_type(x, 'x', (tuple, list), 'check_finite_and_unscale')
+    #for e in x:
+    #    check_variable_and_dtype(e, "x", ['float16', 'float32', 'float64'],
+    #                             'check_finite_and_unscale')
 
     helper = LayerHelper("check_finite_and_unscale", **locals())
     found_inf = helper.create_variable_for_type_inference(dtype='bool')
@@ -404,12 +404,12 @@ def update_loss_scaling(x,
                            loss scaling.
     """
 
-    check_variable_and_dtype(prev_loss_scaling, "prev_loss_scaling",
-                             ['float32', 'float64'], "update_loss_scaling")
-    check_type(x, 'x', (tuple, list), 'update_loss_scaling')
+    #check_variable_and_dtype(prev_loss_scaling, "prev_loss_scaling",
+    #                         ['float32', 'float64'], "update_loss_scaling")
+    #check_type(x, 'x', (tuple, list), 'update_loss_scaling')
     for e in x:
-        check_variable_and_dtype(e, "x", ['float16', 'float32', 'float64'],
-                                 'update_loss_scaling')
+        #check_variable_and_dtype(e, "x", ['float16', 'float32', 'float64'],
+        #                         'update_loss_scaling')
         if e.dtype == core.VarDesc.VarType.FP16:
             assert prev_loss_scaling.dtype == core.VarDesc.VarType.FP32, \
                 "The dtype of prev_loss_scaling should be float32 when the dtype of x is float16."

--- a/plsc/utils/input_field.py
+++ b/plsc/utils/input_field.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import paddle.fluid as fluid
+import paddle
 
 
 class InputField(object):
@@ -74,7 +74,7 @@ class InputField(object):
 
         return self.input_slots[name]
 
-    def build(self, dataset, place, batch_size, num_workers=4):
+    def build(self):
 
         for _name, _shape, _dtype, _lod_level in zip(
                 self.names, self.shapes, self.dtypes, self.lod_levels):
@@ -83,11 +83,3 @@ class InputField(object):
 
         for name in self.feed_list_str:
             self.feed_list.append(self.input_slots[name])
-
-        self.loader = paddle.io.DataLoader(
-            dataset,
-            feed_list=self.feed_list,
-            places=place,
-            batch_size=batch_size,
-            num_workers=num_workers,
-            capacity=capacity)

--- a/plsc/utils/parameter_converter.py
+++ b/plsc/utils/parameter_converter.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,532 +11,199 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
-
-import json
-import logging
-import os
-import shutil
-from functools import cmp_to_key
-
-import paddle
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='[%(levelname)s %(asctime)s line:%(lineno)d] %(message)s',
-    datefmt='%d %b %Y %H:%M:%S')
-logger = logging.getLogger()
+import numpy as np
 
 
-class ParameterConverter(object):
+def rearrange_weight(weight_dict, init_num_rank, new_num_rank):
     """
-    Tool to convert pre-trained distributed fc parameters for inference or
-    fine-tuning. Note that the number of ranks or GPUs for inference or
-    fine-tuning can be different from that for pre-training.
+    A help function to convert pre-trained distributed fc parameters for
+    inference or fine-tuning. Note that the number of ranks or GPUs for
+    inference or fine-tuning can be different from that for pre-training.
+
+    Args:
+        weight_dict(dict): the dict store distributed parameters,
+            key: eg. dist@arcface@rank@00000.w_0
+            value: numpy.ndarray
+        init_num_rank(int) : pre-trained weight at init_num_rank gpu device.
+        new_num_rank(int) : want to rearrange weight to new_num_rank gpu device.
+
+    Returns:
+        dict: rearranged weight for new_num_rank gpu device.
     """
 
-    def __init__(self, model_dir, output_dir, num_trainers):
-        super(ParameterConverter, self).__init__()
-        self.model_dir = model_dir
-        self.output_dir = output_dir
-        self.pretrain_nranks = -1
-        self.emb_dim = -1
-        self.num_classes = -1
-        self.nranks = num_trainers
+    ret_dict = {}
+    if init_num_rank == new_num_rank:
+        return weight_dict
 
-        self.load_config()
+    if len(weight_dict) == 0:
+        return weight_dict
 
-    def load_config(self):
-        """
-        Load config file which contains the following information for
-        pre-training:
-            1. pretrain_nranks (int): number of ranks for pre-training;
-            2. emb_dim (int): embedding dim for pre-training;
-            3. num_classes (int): number of classes for classification.
-        """
-        meta_file = os.path.join(self.model_dir, 'meta.json')
-        if not os.path.exists(meta_file):
-            logger.error(
-                "Meta file does not exist, make sure your pre-trained "
-                "models are legal.")
-            exit()
+    # generate name format
+    name_format = list(weight_dict.keys())[0]
+    name_format = name_format.split('.')
+    name_format[0] = name_format[0].split('@')
+    name_format[0][-1] = '%05d'
+    name_format[0] = '@'.join(name_format[0])
+    name_format = '.'.join(name_format)
 
-        with open(meta_file, 'r') as handle:
-            config = json.load(handle)
+    # calculate num class of pretrain shard
+    # num class of new shard
+    num_class = sum([
+        w.shape[1] if len(w.shape) == 2 else len(w)
+        for _, w in weight_dict.items()
+    ])
+    init_nshard = (num_class + init_num_rank - 1) // init_num_rank
+    new_nshard = (num_class + new_num_rank - 1) // new_num_rank
 
-        self.pretrain_nranks = config['pretrain_nranks']
-        assert self.pretrain_nranks > 0
-        self.emb_dim = config['emb_dim']
-        assert self.emb_dim > 0
-        self.num_classes = config['num_classes']
-        assert self.num_classes > 0
+    if new_nshard * (new_num_rank - 1) >= num_class:
+        raise ValueError(
+            "num class {} cann't be rationally splited by num rank {}".format(
+                num_class, new_num_rank))
 
-        logger.info("Parameters for pre-training: pretrain_nranks ({}), "
-                    "emb_dim ({}), and num_classes ({}).".format(
-                        self.pretrain_nranks, self.emb_dim, self.num_classes))
-        logger.debug("Parameters for inference or fine-tuning: "
-                     "nranks ({}).".format(self.nranks))
+    if init_num_rank > new_num_rank:
+        for new_idx in range(new_num_rank):
+            start = new_idx * new_nshard
+            end = min((new_idx + 1) * new_nshard - 1, num_class - 1)
+            init_shard_idx_start = start // init_nshard
+            init_shard_idx_end = end // init_nshard
 
-    def find_var_names(self):
-        """
-        Find all names of pre-trained parameters for the distributed fc layer,
-        e.g., dist@softmax@rank@00000.w_0, dist@softmax@rank@00000.b_0 etc.
-        We assume that names of distributed fc related parameters start with the
-        prefix dist@ and have @rank@ in their names.
-        """
-        var_names = []
-        model_dir = os.path.abspath(self.model_dir)
-        if not os.path.exists(model_dir):
-            logger.error("The directory for pre-trained model ({}) does not "
-                         "exist, please check it.".format(model_dir))
-            exit()
-        logger.info("The directory for pre-trained model: {}".format(
-            model_dir))
-        for file in os.listdir(model_dir):
-            if 'dist@' in file and '@rank@' in file:
-                var_names.append(file)
-        assert len(var_names) > 0, \
-            logger.error("No distributed fc parameters found.")
-        logger.info("Number of distributed fc parameters: {}.".format(
-            len(var_names)))
-        logger.info("Distributed fc parameters: {}.".format(var_names))
-        return var_names
-
-    def split_load_and_save(self,
-                            name_index,
-                            param_names,
-                            save_rank_id,
-                            remainder,
-                            as_bias,
-                            train_nshards,
-                            train_nranks,
-                            nshards,
-                            dtype="float32"):
-        var2 = None
-        advance = False
-        emb_dim = self.emb_dim
-        main_program = paddle.static.Program()
-        startup_program = paddle.static.Program()
-        num_classes = self.num_classes
-
-        load_var_name = param_names[name_index]
-        save_var_name_list = load_var_name.split('.')
-        save_var_name_list[0] = save_var_name_list[0].split('@')
-        save_var_name_list[0][-1] = "%05d" % save_rank_id
-        save_var_name_list[0] = '@'.join(save_var_name_list[0])
-        save_var_name = '.'.join(save_var_name_list)
-
-        last_train_nshards = num_classes - (train_nranks - 1) * train_nshards
-
-        with paddle.static.program_guard(main_program, startup_program):
-            if name_index == train_nranks - 1:
-                var_dim = last_train_nshards
-            else:
-                var_dim = train_nshards
-
-            shape = [var_dim] if as_bias else [emb_dim, var_dim]
-            var = paddle.static.create_parameter(
-                shape, dtype=dtype, name=load_var_name)
-
-            if as_bias:
-                var = paddle.slice(
-                    var,
-                    axes=[0],
-                    starts=[var.shape[0] - remainder],
-                    ends=[var.shape[0]])
-            else:
-                var = paddle.split(
-                    var, [var.shape[1] - remainder, remainder], dim=1)[1]
-
-            save_var_dim = nshards
-            if remainder < nshards:
-                if name_index == train_nranks - 1:
-                    save_var_dim = remainder
+            weight_list = []
+            for init_idx in range(init_shard_idx_start,
+                                  init_shard_idx_end + 1):
+                name = name_format % init_idx
+                init_weight = weight_dict[name]
+                s = max(start - init_idx * init_nshard, 0)
+                if init_idx == init_shard_idx_end:
+                    e = min(end - init_idx * init_nshard + 1, init_nshard)
                 else:
-                    name_index += 1
-                    advance = True
-                    load_var_name = param_names[name_index]
+                    e = init_nshard
+                if len(init_weight.shape) == 2:
+                    weight_list.append(init_weight[:, s:e])
+                else:
+                    weight_list.append(init_weight[s:e])
 
-                    if name_index == train_nranks - 1:
-                        var_dim = last_train_nshards
+            name = name_format % new_idx
+            # for 2-dimention, we concat at axis=1,
+            # else for 1-dimention, we concat at axis=0
+            ret_dict[name] = np.concatenate(
+                weight_list, axis=len(weight_list[0].shape) - 1)
+    else:
+        for new_idx in range(new_num_rank):
+            start = new_idx * new_nshard
+            end = min((new_idx + 1) * new_nshard - 1, num_class - 1)
+            init_shard_idx_start = start // init_nshard
+            init_shard_idx_end = end // init_nshard
+
+            if init_shard_idx_start == init_shard_idx_end:
+                name = name_format % init_shard_idx_start
+                init_weight = weight_dict[name]
+                init_start = init_shard_idx_start * init_nshard
+                s = max(start - init_start, 0)
+                e = min((init_shard_idx_start + 1) * init_nshard,
+                        end) - init_start + 1
+                if len(init_weight.shape) == 2:
+                    new_weight = init_weight[:, s:e]
+                else:
+                    new_weight = init_weight[s:e]
+            else:
+                # init_shard_idx_start + 1 == init_shard_idx_end
+                name = name_format % init_shard_idx_start
+                init_weight = weight_dict[name]
+                init_start = init_shard_idx_start * init_nshard
+                s = max(start - init_start, 0)
+                if len(init_weight.shape) == 2:
+                    new_weight = init_weight[:, s:]
+                else:
+                    new_weight = init_weight[s:]
+
+                e = end - (init_shard_idx_end * init_nshard) + 1
+                if e > 0:
+                    name = name_format % init_shard_idx_end
+                    init_weight = weight_dict[name]
+                    if len(init_weight.shape) == 2:
+                        new_weight2 = init_weight[:, :e]
                     else:
-                        var_dim = train_nshards
-                    shape = [var_dim] if as_bias else [emb_dim, var_dim]
-                    var2 = paddle.static.create_parameter(
-                        shape, dtype=dtype, name=load_var_name)
+                        new_weight2 = init_weight[:e]
 
-                    if remainder + var_dim < nshards:
-                        # The last train rank
-                        save_var_dim = remainder + var_dim
-                    else:
-                        remainder = remainder + var_dim - nshards
-            elif remainder == nshards:
-                if name_index == train_nranks - 2:
-                    remainder = last_train_nshards
-                    advance = True
-                elif name_index < train_nranks - 2:
-                    remainder = train_nshards
-                    advance = True
-            else:
-                remainder = remainder - nshards
-            if var2 is not None:
-                var = paddle.concat([var, var2], axis=0 if as_bias else 1)
+                    new_weight = np.concatenate(
+                        [new_weight, new_weight2],
+                        axis=len(new_weight.shape) - 1)
+            name = name_format % new_idx
+            ret_dict[name] = new_weight
 
-            shape = [save_var_dim] if as_bias else [emb_dim, save_var_dim]
-            to_save_var = paddle.static.create_parameter(
-                shape, dtype=dtype, name=save_var_name + '_temp')
-            if save_var_dim != nshards:  # get last dim
-                if as_bias:
-                    temp_var = paddle.slice(
-                        var,
-                        axes=[0],
-                        starts=[var.shape[0] - save_var_dim],
-                        ends=[var.shape[0]])
-                else:
-                    temp_var = paddle.split(
-                        var, [var.shape[1] - save_var_dim, save_var_dim],
-                        dim=1)[1]
-                paddle.assign(temp_var, to_save_var)
-            else:
-                if as_bias:
-                    temp_var = paddle.slice(
-                        var, axes=[0], starts=[0], ends=[nshards])
-                else:
-                    temp_var = paddle.split(
-                        var, [nshards, var.shape[1] - nshards], dim=1)[0]
-                paddle.assign(temp_var, to_save_var)
+    return ret_dict
 
-        def expected_var(var):
-            has_var = os.path.exists(os.path.join(self.model_dir, var.name))
-            if has_var:
-                return True
-            return False
 
-        place = paddle.CPUPlace()
-        exe = paddle.static.Executor(place)
-        exe.run(startup_program)
-        paddle.static.load(
-            main_program, self.model_dir, exe, predicate=expected_var)
-        exe.run(main_program)
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
-        paddle.static.save(main_program, self.output_dir)
-        srcfile = os.path.join(self.output_dir, to_save_var.name)
-        dstfile = os.path.join(self.output_dir, save_var_name)
-        shutil.move(srcfile, dstfile)
-        return remainder, advance
+if __name__ == '__main__':
 
-    def split_parameters(self, param_names, as_bias):
-        """
-        Split parameters whose names are in param_names.
-        Params:
-            param_names: list of names of parameters to split
-            as_bias: whether parameters to split are as bias or not
-        """
-        num_classes = self.num_classes
-        train_nranks = self.pretrain_nranks
-        nranks = self.nranks
+    def generate_data(num_rank, is_bias=False):
+        num_dim = 2
+        num_class = 16
+        nshard = (num_class + num_rank - 1) // num_rank
 
-        train_nshards = (num_classes + train_nranks - 1) // train_nranks
-        nshards = (num_classes + nranks - 1) // nranks
+        weight_dict = {}
 
-        save_rank_id = 0
-        # remainder dim that is not split in a var
-        remainder_var_dim = train_nshards
-        name_index = 0  # index of name of pre-trained parameter to process
-        for save_rank_id in range(nranks):
-            assert name_index < train_nranks
-            remainder_var_dim, advance = self.split_load_and_save(
-                name_index, param_names, save_rank_id, remainder_var_dim,
-                as_bias, train_nshards, train_nranks, nshards)
-            name_index += 1 if advance else 0
-        processed_var_count = name_index + 1
-
-        assert processed_var_count == train_nranks, \
-            logger.error("Number of pre-trained parameters processed ({}) is "
-                         "not equal to the number of ranks ({}) for "
-                         "pre-training.".format(processed_var_count,
-                                                train_nranks))
-        assert save_rank_id == nranks - 1, \
-            logger.error("Number of saved parameters ({}) is not equal to the "
-                         "number of ranks ({}) for inference or "
-                         "fine-tuning.".format(save_rank_id + 1, nranks))
-
-    def split_distfc_parameters(self, weight_param_names,
-                                weight_velocity_param_names, bias_param_names,
-                                bias_velocity_param_names):
-        """
-        Split each distributed fc-related parameter according to number of ranks
-        for inference or fine-tuning.
-
-        Params:
-            weight_param_names: list of names of weight parameters
-            bias_param_names: list of names of bias parameters
-        """
-        self.split_parameters(weight_param_names, as_bias=False)
-        self.split_parameters(weight_velocity_param_names, as_bias=False)
-        if len(bias_param_names) != 0:
-            self.split_parameters(bias_param_names, as_bias=True)
-            self.split_parameters(bias_velocity_param_names, as_bias=True)
-
-    def concat_load_and_save(self,
-                             name_index,
-                             param_names,
-                             save_rank_id,
-                             remainder,
-                             as_bias,
-                             train_nshards,
-                             train_nranks,
-                             nshards,
-                             dtype="float32"):
-        advance = 0
-        emb_dim = self.emb_dim
-        main_program = paddle.static.Program()
-        startup_program = paddle.static.Program()
-        num_classes = self.num_classes
-
-        load_var_name = param_names[name_index]
-        save_var_name_list = load_var_name.split('.')
-        save_var_name_list[0] = save_var_name_list[0].split('@')
-        save_var_name_list[0][-1] = "%05d" % save_rank_id
-        save_var_name_list[0] = '@'.join(save_var_name_list[0])
-        save_var_name = '.'.join(save_var_name_list)
-
-        last_train_nshards = num_classes - (train_nranks - 1) * train_nshards
-
-        with paddle.static.program_guard(main_program, startup_program):
-            if name_index == train_nranks - 1:
-                var_dim = last_train_nshards
-            else:
-                var_dim = train_nshards
-
-            shape = [var_dim] if as_bias else [emb_dim, var_dim]
-            var = paddle.static.create_parameter(
-                shape, dtype=dtype, name=load_var_name)
-
-            if as_bias:
-                var = paddle.slice(
-                    var,
-                    axes=[0],
-                    starts=[var.shape[0] - remainder],
-                    ends=[var.shape[0]])
-            else:
-                var = paddle.split(
-                    var, [var.shape[1] - remainder, remainder], dim=1)[1]
-            to_concat_var_list = [var]
-            while remainder < nshards and name_index < train_nranks - 1:
-                name_index += 1
-                advance += 1
-                load_var_name = param_names[name_index]
-                if name_index == train_nranks - 1:
-                    var_dim = last_train_nshards
-                else:
-                    var_dim = train_nshards
-                shape = [var_dim] if as_bias else [emb_dim, var_dim]
-                var = paddle.static.create_parameter(
-                    shape, dtype=dtype, name=load_var_name)
-
-                to_concat_var_list.append(var)
-                remainder += var_dim
-            if len(to_concat_var_list) > 1:
-                var = paddle.concat(
-                    to_concat_var_list, axis=0 if as_bias else 1)
-            save_var_dim = nshards
-            if remainder > nshards:
-                if as_bias:
-                    var = paddle.slice(
-                        var, axes=[0], starts=[0], ends=[nshards])
-                else:
-                    var = paddle.split(
-                        var, [nshards, var.shape[1] - nshards], dim=1)[0]
-                remainder = remainder - nshards
-            elif remainder == nshards:
-                if name_index == train_nranks - 2:
-                    # advance += 1 if len(to_concat_var_list) > 1 else 0
-                    # to avoid duplicate add
-                    # name_index += 1 if len(to_concat_var_list) > 1 else 0
-                    # to avoid duplicate add
-                    advance += 1
-                    name_index += 1
-                    remainder = last_train_nshards
-                elif name_index < train_nranks - 2:
-                    # advance += 1 if len(to_concat_var_list) > 1 else 0
-                    # to avoid duplicate add
-                    # name_index += 1 if len(to_concat_var_list) > 1 else 0
-                    # to avoid duplicate add
-                    advance += 1
-                    name_index += 1
-                    remainder = train_nshards
-            else:
-                save_var_dim = remainder
-
-            shape = [save_var_dim] if as_bias else [emb_dim, save_var_dim]
-            to_save_var = paddle.static.create_parameter(
-                shape, dtype=dtype, name=save_var_name + '_temp')
-
-            paddle.assign(var, to_save_var)
-
-        def expected_var(var):
-            has_var = os.path.exists(os.path.join(self.model_dir, var.name))
-            if has_var:
-                return True
-            return False
-
-        place = paddle.CPUPlace()
-        exe = paddle.static.Executor(place)
-        exe.run(startup_program)
-        paddle.static.load(
-            main_program, dirname=self.model_dir, exe, predicate=expected_var)
-        exe.run(main_program)
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
-        paddle.static.save(main_program, self.output_dir)
-        srcfile = os.path.join(self.output_dir, to_save_var.name)
-        dstfile = os.path.join(self.output_dir, save_var_name)
-        shutil.move(srcfile, dstfile)
-        return remainder, advance
-
-    def concat_parameters(self, param_names, as_bias):
-        """
-        Concat parameters whose names are in param_names.
-        Params:
-            param_names: list of names of parameters to concat
-            as_bias: whether parameters to split are as bias or not
-        """
-        num_classes = self.num_classes
-        train_nranks = self.pretrain_nranks
-        nranks = self.nranks
-
-        train_nshards = (num_classes + train_nranks - 1) // train_nranks
-        nshards = (num_classes + nranks - 1) // nranks
-
-        save_rank_id = 0
-        remainder_dim = train_nshards  # remainder dim that is not concated
-        name_index = 0  # index of name of pre-trained parameter to process
-        for save_rank_id in range(nranks):
-            assert name_index < train_nranks
-            remainder_dim, advance = self.concat_load_and_save(
-                name_index, param_names, save_rank_id, remainder_dim, as_bias,
-                train_nshards, train_nranks, nshards)
-            name_index += advance
-        processed_var_count = name_index + 1
-
-        assert processed_var_count == train_nranks, \
-            logger.error("Number of pre-trained parameters processed ({}) is "
-                         "not equal to the number of ranks ({}) for "
-                         "pre-training.".format(processed_var_count,
-                                                train_nranks))
-        assert save_rank_id == nranks - 1, \
-            logger.error("Number of saved parameters ({}) is not equal to the "
-                         "number of ranks ({}) for inference or "
-                         "fine-tuning.".format(save_rank_id + 1, nranks))
-
-    def concat_distfc_parameters(self, weight_param_names,
-                                 weight_velocity_param_names, bias_param_names,
-                                 bias_velocity_param_names):
-        """
-        Concat distributed fc-related parameters according to number of ranks
-        for inference or finetuning.
-
-        Params:
-            weight_param_names: list of names of weight parameters
-            weight_velocity_param_names: list of names of weight velocity
-                parameters
-            bias_param_names: list of names of bias parameters
-            bias_velocity_param_names: list of names of bias velocity parameters
-        """
-        self.concat_parameters(weight_param_names, as_bias=False)
-        self.concat_parameters(weight_velocity_param_names, as_bias=False)
-        if len(bias_param_names) != 0:
-            self.concat_parameters(bias_param_names, as_bias=True)
-            self.concat_parameters(bias_velocity_param_names, as_bias=True)
-
-    def process(self):
-        self.load_config()
-        var_names = self.find_var_names()
-        weight_param_names = [
-            name for name in var_names
-            if '.w' in name and 'velocity' not in name
-        ]
-        weight_velocity_param_names = [
-            name for name in var_names if '.w' in name and 'velocity' in name
-        ]
-        bias_param_names = [
-            name for name in var_names
-            if '.b' in name and 'velocity' not in name
-        ]
-        bias_velocity_param_names = [
-            name for name in var_names if '.b' in name and 'velocity' in name
-        ]
-
-        def parameter_name_compare(x, y):
-            """
-            Compare two parameter names depend on their rank id.
-            A parameter name is like dist_softmax_rank_00000.w_0,
-            where 00000 is the rank id.
-            """
-            rank_id_x = int(x.split('.')[0].split('@')[-1])
-            rank_id_y = int(y.split('.')[0].split('@')[-1])
-            if rank_id_x < rank_id_y:
-                return -1
-            elif rank_id_x == rank_id_y:
-                return 0
-            else:
-                return 1
-
-        weight_param_names.sort(key=cmp_to_key(parameter_name_compare))
-        weight_velocity_param_names.sort(
-            key=cmp_to_key(parameter_name_compare))
-        bias_param_names.sort(key=cmp_to_key(parameter_name_compare))
-        bias_velocity_param_names.sort(key=cmp_to_key(parameter_name_compare))
-
-        assert len(weight_param_names) == self.pretrain_nranks, \
-            logger.error(
-                "Number of distributed fc-related weight parameters ({}) "
-                "should be equal to the number of ranks ({}) for "
-                "pre-training.".format(len(weight_param_names),
-                                       self.pretrain_nranks))
-        assert len(weight_velocity_param_names) == self.pretrain_nranks, \
-            logger.error(
-                "Number of distributed fc-related weight parameters ({}) "
-                "should be equal to the number of ranks ({}) for "
-                "pre-training.".format(len(weight_velocity_param_names),
-                                       self.pretrain_nranks))
-        assert (len(bias_param_names) == 0 or
-                len(bias_param_names) == self.pretrain_nranks), \
-            logger.error(
-                "Number of distributed fc-related bias parameters ({}) "
-                "should be 0 or equal to the number of ranks ({}) for "
-                "pre-training.".format(len(bias_param_names),
-                                       self.pretrain_nranks))
-        assert (len(bias_velocity_param_names) == 0 or
-                len(bias_velocity_param_names) == self.pretrain_nranks), \
-            logger.error(
-                "Number of distributed fc-related bias parameters ({}) "
-                "should be 0 or equal to the number of ranks ({}) for "
-                "pre-training.".format(len(bias_velocity_param_names),
-                                       self.pretrain_nranks))
-
-        pretrain_nranks = self.pretrain_nranks
-        nranks = self.nranks
-        if pretrain_nranks == nranks:
-            logger.info(
-                "Pre-training and inference (or fine-tuning) have the same "
-                "number of ranks, nothing to do.")
-        elif pretrain_nranks < nranks:
-            self.split_distfc_parameters(
-                weight_param_names, weight_velocity_param_names,
-                bias_param_names, bias_velocity_param_names)
+        if is_bias:
+            data = np.array(range(num_class))
         else:
-            self.concat_distfc_parameters(
-                weight_param_names, weight_velocity_param_names,
-                bias_param_names, bias_velocity_param_names)
+            data = np.array(range(num_dim * num_class)).reshape(
+                (num_dim, num_class))
+        print('fc weight:')
+        print(data)
 
-        logger.info("Done.")
+        print('shard fc weight:')
+        for i in range(num_rank):
+            name = 'dist@arcface@rank@%05d.w_0' % i
+            start = i * nshard
+            end = min((i + 1) * nshard, num_class)
+            if is_bias:
+                weight_dict[name] = data[start:end]
+            else:
+                weight_dict[name] = data[:, start:end]
+            print(name)
+            print(weight_dict[name])
 
+        return weight_dict
 
-if __name__ == "__main__":
-    converter = ParameterConverter('./trained_model', "./trained_model_temp",
-                                   8)
-    converter.process()
+    def generate_data1(num_rank, is_bias=False):
+        num_dim = 2
+        num_class = 85742
+        nshard = (num_class + num_rank - 1) // num_rank
+
+        weight_dict = {}
+
+        if is_bias:
+            data = np.array(range(num_class))
+        else:
+            data = np.array(range(num_dim * num_class)).reshape(
+                (num_dim, num_class))
+        print('fc weight:')
+        print(data.shape)
+
+        print('shard fc weight:')
+        for i in range(num_rank):
+            name = 'dist@arcface@rank@%05d.w_0' % i
+            start = i * nshard
+            end = min((i + 1) * nshard, num_class)
+            if is_bias:
+                weight_dict[name] = data[start:end]
+            else:
+                weight_dict[name] = data[:, start:end]
+            print(name)
+            print(weight_dict[name].shape)
+
+        print()
+        return weight_dict
+
+    init_num_rank = 3
+    new_num_rank = 6
+    is_bias = False
+    weight_dict = generate_data1(init_num_rank, is_bias)
+
+    weight_dict = rearrange_weight(weight_dict, init_num_rank, new_num_rank)
+    num_class = 0
+    for n, w in weight_dict.items():
+        print(n)
+        print(w.shape)
+        num_class += w.shape[-1]
+    print(num_class)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from plsc import Entry
+
+if __name__ == "__main__":
+    ins = Entry()
+    ins.set_dataset_dir('/path/to/your/data/folder/')
+    ins.set_loss_type('dist_arcface')
+    #ins.set_mixed_precision(True)
+    ins.set_train_epochs(50)
+    ins.set_test_period(2000)
+    ins.set_calc_acc(True)
+    ins.set_model_save_dir('./saved_model')
+    ins.train()

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 -m paddle.distributed.launch --gpus=0,1,2,3,4,5,6,7 train.py


### PR DESCRIPTION
本次 PR 主要是将 PLSC 仓库从 Paddle 1.x 升级适配到 Paddle 2.1 API 接口

除了API改变以外，还做了如下几点改进：

* 重新实现了 dist-softmax 和 dist-arcface 的 fp16 混合训练逻辑
* 重新实现了checkpoint 保存和加载的 save，load 函数
* 重新实现了 resume 逻辑，训练停止后，可以直接设置 checkpoint dir 进行自动恢复，不用做任何修改接着训练
* 重新实现了 dist-fc 参数在保存前训练和当前训练GPU数量不一致时，dist-fc 参数重新划分逻辑
* 重新实现了训练阶段的数据加载方式，基于 Dataset 和 DataLoader，对齐动态图使用习惯