### PR TITLE
change loss.numpy()[0] to float(loss) to adapt 0D

### DIFF
--- a/plsc/engine/classification/evaluation.py
+++ b/plsc/engine/classification/evaluation.py
@@ -70,8 +70,7 @@ def default_eval(engine, epoch_id=0):
                 for key in loss_dict:
                     if key not in output_info:
                         output_info[key] = AverageMeter(key, '7.5f')
-                    output_info[key].update(loss_dict[key].numpy()[0],
-                                            batch_size)
+                    output_info[key].update(float(loss_dict[key]), batch_size)
 
         # just for DistributedBatchSampler issue: repeat sampling
         current_samples = batch_size * paddle.distributed.get_world_size()


### PR DESCRIPTION
loss正确的语义为0D Tensor，也就是标量Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在升级为0D后，`loss.numpy()[0]` 的写法将不再适用，因此将其改变为 `float(loss)` 的写法，升级前(shape为[1])、升级后(shape为[])都能适用，兼容前后写法。